### PR TITLE
Request news with a category

### DIFF
--- a/apps/news/routes/index.js
+++ b/apps/news/routes/index.js
@@ -10,11 +10,12 @@ const router = express.Router();
 router.route('/')
   .post((req, res) => {
     const snipsMessage = req.body;
+	const requestedCategory = snipsMessage.slots[0].value.value;
     console.log(JSON.stringify(snipsMessage));
 
     // poll News API for headlines
     request({
-	  url: `https://newsapi.org/v2/top-headlines?country=${config.country}&apiKey=${secrets.apiKey}`,
+	  url: `https://newsapi.org/v2/top-headlines?country=${config.country}&category=${requestedCategory}&apiKey=${secrets.apiKey}`,
       method: 'GET'
     }, (error, response, body) => {
       let responseText = '';

--- a/apps/news/routes/index.js
+++ b/apps/news/routes/index.js
@@ -10,12 +10,21 @@ const router = express.Router();
 router.route('/')
   .post((req, res) => {
     const snipsMessage = req.body;
-	const requestedCategory = snipsMessage.slots[0].value.value;
-    console.log(JSON.stringify(snipsMessage));
-
+	console.log(JSON.stringify(snipsMessage));
+	
+	const requestedCategory = snipsMessage.slots[0].rawValue;
+	let requestUrl = '';
+	if(requestedCategory == 'headline') {
+		requestUrl = `https://newsapi.org/v2/top-headlines?country=${config.country}&apiKey=${secrets.apiKey}`;
+	}
+	else {
+		requestUrl = `https://newsapi.org/v2/top-headlines?country=${config.country}&category=${requestedCategory}&apiKey=${secrets.apiKey}`;
+	}
+	
     // poll News API for headlines
     request({
-	  url: `https://newsapi.org/v2/top-headlines?country=${config.country}&category=${requestedCategory}&apiKey=${secrets.apiKey}`,
+	  url: requestUrl,
+	  // url: `https://newsapi.org/v2/top-headlines?country=${config.country}&category=${requestedCategory}&apiKey=${secrets.apiKey}`,
       method: 'GET'
     }, (error, response, body) => {
       let responseText = '';


### PR DESCRIPTION
You should be able to ask for one of the following categories for the headline:

- business 
- entertainment 
- general 
- health 
- science 
- sports 
- technology

So you can now ask snips for a specific type of news, e.g. "Give me a general headline" or "Give me a sports headline".
The old behaviour still works: Just ask for a random or top headline.

The snips intent is also updated.